### PR TITLE
Export WebDavException.

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -185,12 +185,12 @@ class Client {
 
   /// upload a new file with [localData] as content to [remotePath]
   Future upload(Uint8List data, String remotePath) async {
-    this._upload(data, remotePath);
+    await this._upload(data, remotePath);
   }
 
   /// upload local file [path] to [remotePath]
   Future uploadFile(String path, String remotePath) async {
-    this._upload(await File(path).readAsBytes(), remotePath);
+    await this._upload(await File(path).readAsBytes(), remotePath);
   }
 
   /// download [remotePath] to local file [localFilePath]

--- a/lib/webdav.dart
+++ b/lib/webdav.dart
@@ -1,4 +1,4 @@
 library webdav;
 
-export 'package:webdav/src/client.dart' show Client;
+export 'package:webdav/src/client.dart' show Client, WebDavException;
 export 'package:webdav/src/file.dart' show FileInfo;


### PR DESCRIPTION
2 small fixes:

Export WebDavException.
Some operations may throw an exception.
This change allows to handle that in the app.

Fix synchronization of upload() and uploadFile() methods.
Without the change they are always executed asynchronously, i.e. it is not possible to wait for transfer completion.



